### PR TITLE
Bug 370323 - Bugzilla: Make sure charset is UTF-8 in responses

### DIFF
--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_collection_html.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_collection_html.jsp
@@ -1,6 +1,6 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -16,7 +16,7 @@
 --%>
 <%@page import="org.eclipse.lyo.samples.bugzilla.URLStrategy"%>
 <%@page import="org.eclipse.lyo.samples.bugzilla.jbugzx.base.Product"%>
-<%@ page contentType="text/html" language="java" %>
+<%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
 <%@ page import="com.j2bugzilla.base.*" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.jbugzx.base.*" %>
 <%@ page import="java.util.List" %>
@@ -29,6 +29,7 @@
 %>
 <html>
 	<head>
+		<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 		<title>Bugzilla OSLC Adapter: Service Provider for <%= product.getName() + "(" + product.getId() + ")" %></title>
 		<link href="<%= bugzillaUri %>/skins/standard/global.css" rel="stylesheet" type="text/css">
 		<link href="<%= bugzillaUri %>/skins/standard/index.css" rel="stylesheet" type="text/css">

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_created.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_created.jsp
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -14,6 +15,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
+<%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
 <%@ page import="java.net.*,java.util.*,java.text.SimpleDateFormat" %> 
 <%@ page import="com.j2bugzilla.base.Bug" %>
 <% 
@@ -22,6 +24,7 @@ String bugUri  = (String)request.getAttribute("bugUri");
 String title   = bug.getSummary();
 %>
 <head>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 <script type="text/javascript">
    // Step #2: read the return URL 
    var returnURL = window.name;

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_creator.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_creator.jsp
@@ -1,5 +1,6 @@
+<!DOCTYPE html>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +14,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
+<%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
 <%@page import="org.eclipse.lyo.samples.bugzilla.URLStrategy"%>
 <%@ page import="java.util.List" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.jbugzx.base.Product" %>
@@ -26,6 +28,7 @@
 %>
 <html>
 <head>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 <title>Bugzilla OSLC Adapter: Resource Creator</title>
 <link href="<%= bugzillaUri %>/skins/standard/global.css" rel="stylesheet" type="text/css">
 <link href="<%= bugzillaUri %>/skins/standard/index.css" rel="stylesheet" type="text/css">

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_filtered_json.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_filtered_json.jsp
@@ -1,5 +1,5 @@
 <%-- 
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -13,7 +13,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
-<%@ page contentType="application/json" language="java" %>
+<%@ page contentType="application/json" language="java" pageEncoding="UTF-8" %>
 <%@page import="org.eclipse.lyo.samples.bugzilla.URLStrategy"%>
 <%@ page import="java.net.*,java.util.*" %> 
 <%@ page import="com.j2bugzilla.base.Bug" %>

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_preview_desc.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_preview_desc.jsp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
-<%@ page contentType="application/x-oslc-compact+xml" language="java" %>
+<%@ page contentType="application/x-oslc-compact+xml" language="java" pageEncoding="UTF-8" %>
 <%@ page import="com.j2bugzilla.base.Bug" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.URLStrategy"%>
 <% 

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_preview_large.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_preview_large.jsp
@@ -1,5 +1,6 @@
+<!DOCTYPE html>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -13,7 +14,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
-<%@ page contentType="text/html" language="java" %>
+<%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
 <%@ page import="java.net.*,java.util.*" %>
 <%@ page import="java.net.*,java.util.*,java.text.SimpleDateFormat" %>
 <%@ page import="com.j2bugzilla.base.Bug" %>

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_preview_small.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_preview_small.jsp
@@ -1,5 +1,6 @@
+<!DOCTYPE html>
 <!--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -13,7 +14,7 @@
  
     IBM Corporation - initial API and implementation
  -->
-<%@ page contentType="text/html" language="java" %>
+<%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
 <%@ page import="java.net.*,java.util.*,java.text.SimpleDateFormat" %>
 <%@ page import="com.j2bugzilla.base.Bug" %>
 <%
@@ -33,6 +34,7 @@ String assignee = (String)bug.getParameterMap().get("assigned_to");
 %>
 <html>
 <head>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 <title>Change Request: <%=title %> (<%=identifier %>)</title>
 <link href="<%= bugzillaUri %>/skins/standard/global.css" rel="stylesheet" type="text/css">
 <link href="<%= bugzillaUri %>/skins/standard/index.css" rel="stylesheet" type="text/css">

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_selector.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/changerequest_selector.jsp
@@ -1,5 +1,6 @@
+<!DOCTYPE html>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +14,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
+<%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
 <%@ page import="com.j2bugzilla.base.*" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.URLStrategy"%>
 <%
@@ -21,6 +23,7 @@ String bugzillaUri = (String) request.getAttribute("bugzillaUri");
 %>
 <html>
 <head>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 <title>Bugzilla OSLC Adapter: Resource Selector</title>
 <link href="<%= bugzillaUri %>/skins/standard/global.css" rel="stylesheet" type="text/css">
 <link href="<%= bugzillaUri %>/skins/standard/index.css" rel="stylesheet" type="text/css">

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/resourceshape_creation_rdfxml.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/resourceshape_creation_rdfxml.jsp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
-<%@ page contentType="application/x-oslc-compact+xml" language="java"%>
+<%@ page contentType="application/x-oslc-compact+xml" language="java" pageEncoding="UTF-8" %>
 <%@ page import="java.util.List" %>
 <%@ page import="com.j2bugzilla.base.Bug" %>
 <%

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/resourceshape_query_cr_rdfxml.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/resourceshape_query_cr_rdfxml.jsp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
-<%@ page contentType="application/x-oslc-compact+xml" language="java"%>
+<%@ page contentType="application/x-oslc-compact+xml" language="java" pageEncoding="UTF-8" %>
 <%@ page import="java.util.List" %>
 <%@ page import="com.j2bugzilla.base.Bug" %>
 <%

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/resourceshape_query_rdfxml.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/resourceshape_query_rdfxml.jsp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
-<%@ page contentType="application/x-oslc-compact+xml" language="java"%>
+<%@ page contentType="application/x-oslc-compact+xml" language="java" pageEncoding="UTF-8" %>
 <%@ page import="java.util.List" %>
 <%@ page import="com.j2bugzilla.base.Bug" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.jbugzx.base.Product" %>

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/rootservices_rdfxml.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/rootservices_rdfxml.jsp
@@ -14,8 +14,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
-<%@ page contentType="application/rdf+xml" language="java" %>
-<%@ page pageEncoding="UTF-8" %>
+<%@ page contentType="application/rdf+xml" language="java" pageEncoding="UTF-8" %>
 <%
 String baseUri = (String) request.getAttribute("baseUri");
 %>

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/serviceprovider_html.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/serviceprovider_html.jsp
@@ -1,6 +1,6 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
-<%@ page contentType="text/html" language="java" %>
+<%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
 <%@ page import="java.util.List" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.jbugzx.base.Product" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.URLStrategy"%>
@@ -24,6 +24,7 @@ Product product = (Product)request.getAttribute("product");
 %>
 <html>
 	<head>
+		<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 		<title>Bugzilla OSLC Adapter: Service Provider for <%= product.getName() + "(" + product.getId() + ")" %></title>
 		<link href="<%= bugzillaUri %>/skins/standard/global.css" rel="stylesheet" type="text/css">
 		<link href="<%= bugzillaUri %>/skins/standard/index.css" rel="stylesheet" type="text/css">

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/serviceprovider_rdfxml.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/serviceprovider_rdfxml.jsp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
-<%@ page contentType="application/rdf+xml" language="java"%>
+<%@ page contentType="application/rdf+xml" language="java" pageEncoding="UTF-8" %>
 <%@ page import="java.util.List" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.jbugzx.base.Product" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.URLStrategy"%>

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/serviceprovidercatalog_html.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/serviceprovidercatalog_html.jsp
@@ -1,6 +1,6 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
-<%@ page contentType="text/html" language="java"%>
+<%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
 <%@ page import="java.util.List" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.jbugzx.base.Product" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.URLStrategy"%>
@@ -24,6 +24,7 @@ List<Product> products = (List<Product>)request.getAttribute("products");
 %>
 <html>
 	<head>
+		<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 		<title>Bugzilla OSLC Adapter: Service Provider Catalog</title>
 		<link href="<%= bugzillaUri %>/skins/standard/global.css" rel="stylesheet" type="text/css">
 		<link href="<%= bugzillaUri %>/skins/standard/index.css" rel="stylesheet" type="text/css">

--- a/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/serviceprovidercatalog_rdfxml.jsp
+++ b/org.eclipse.lyo.samples.bugzilla/src/main/webapp/cm/serviceprovidercatalog_rdfxml.jsp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <%--
- Copyright (c) 2011 IBM Corporation.
+ Copyright (c) 2011, 2012 IBM Corporation.
 
  All rights reserved. This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,7 @@
  
     IBM Corporation - initial API and implementation
 --%>
-<%@ page contentType="application/rdf+xml" language="java"%>
+<%@ page contentType="application/rdf+xml" language="java" pageEncoding="UTF-8" %>
 <%@ page import="java.util.List" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.jbugzx.base.Product" %>
 <%@ page import="org.eclipse.lyo.samples.bugzilla.URLStrategy"%>


### PR DESCRIPTION
Add pageEncoding declarations to all JSPs and make sure we have
consistent doctype and meta charset elements in our HTML responses.
