### PR TITLE
Bug 370338 - Update POM to pull j2bugzilla from central Maven repo

### DIFF
--- a/org.eclipse.lyo.samples.bugzilla/README.txt
+++ b/org.eclipse.lyo.samples.bugzilla/README.txt
@@ -1,15 +1,6 @@
 You must have Bugzilla 4.0 to run this sample. Simplest is to
 connect to the Bugzilla Landfull <http://landfill.bugzilla.org/>.
 
-This project also relies on j2bugzilla, a Java API for Bugzilla.
-Download j2bugzilla 1.0 from Google Code,
-
-  http://j2bugzilla.googlecode.com/files/j2bugzilla-1.0.jar
-
-Then install j2bugzilla into your local repository with the command,
-
-  mvn install:install-file -Dfile=j2bugzilla-1.0.jar -DgroupId=j2bugzilla -DartifactId=j2bugzilla -Dversion=1.0 -Dpackaging=jar
-
 To run the Bugzilla adapter, edit src/main/resources/bugz.properties to
 point to your Bugzilla server (or use the default, Bugzilla Landfill).
 Then from the project root directory,

--- a/org.eclipse.lyo.samples.bugzilla/pom.xml
+++ b/org.eclipse.lyo.samples.bugzilla/pom.xml
@@ -59,22 +59,13 @@
    			<artifactId>jenabean</artifactId> 
    			<version>1.0.6</version> 
 		</dependency>
-
-		<!--
-			Download j2bugzilla 1.0 from Google Code.
-	
-				http://j2bugzilla.googlecode.com/files/j2bugzilla-1.0.jar
-	
-			Install j2bugzilla into your local repository with the command,
-	
-	 				mvn install:install-file -Dfile=j2bugzilla-1.0.jar -DgroupId=j2bugzilla -DartifactId=j2bugzilla -Dversion=1.0 -Dpackaging=jar
-		-->
-		<dependency>
-			<groupId>j2bugzilla</groupId>
-			<artifactId>j2bugzilla</artifactId>
-			<version>1.0</version>
-		</dependency>
 		
+		<dependency>
+  			<groupId>com.j2bugzilla</groupId>
+  			<artifactId>j2bugzilla</artifactId>
+  			<version>1.0</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-webapp</artifactId>


### PR DESCRIPTION
j2bugzilla is now available in the central Maven repository. Update the
POM to use that version.
