### PR TITLE
Inject Multimap with POST params through an HttpServletRequestWrapper

### DIFF
--- a/oauth-core/pom.xml
+++ b/oauth-core/pom.xml
@@ -47,10 +47,15 @@
 
         <!-- Generic -->
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.servlet</artifactId>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+
 
         <!-- Test -->
         <dependency>

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthConfiguration.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthConfiguration.java
@@ -1,18 +1,14 @@
-/*******************************************************************************
- * Copyright (c) 2012 IBM Corporation.
+/*
+ * Copyright (c) 2012-2019 IBM Corporation and others
  *
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Eclipse Distribution License v. 1.0 which accompanies this distribution.
- *  
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Eclipse Distribution License is available at
- *  http://www.eclipse.org/org/documents/edl-v10.php.
- *  
- *  Contributors:
- *  
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
 package org.eclipse.lyo.server.oauth.core;
 
 import javax.servlet.http.HttpServletResponse;
@@ -24,6 +20,8 @@ import net.oauth.http.HttpMessage;
 
 import org.eclipse.lyo.server.oauth.core.consumer.ConsumerStore;
 import org.eclipse.lyo.server.oauth.core.consumer.ConsumerStoreException;
+import org.eclipse.lyo.server.oauth.core.token.IJaxTokenStrategy;
+import org.eclipse.lyo.server.oauth.core.token.JaxTokenStrategy;
 import org.eclipse.lyo.server.oauth.core.token.SimpleTokenStrategy;
 import org.eclipse.lyo.server.oauth.core.token.TokenStrategy;
 
@@ -36,6 +34,7 @@ import org.eclipse.lyo.server.oauth.core.token.TokenStrategy;
 public class OAuthConfiguration {
 	private OAuthValidator validator;
 	private TokenStrategy tokenStrategy;
+	private IJaxTokenStrategy jaxTokenStrategy;
 	private ConsumerStore consumerStore = null;
 	private Application application = null;
 	private boolean v1_0Allowed = true;
@@ -49,6 +48,7 @@ public class OAuthConfiguration {
 	private OAuthConfiguration() {
 		validator = new SimpleOAuthValidator();
 		tokenStrategy = new SimpleTokenStrategy();
+		jaxTokenStrategy = new JaxTokenStrategy(128, 1024);
 	}
 
 	/**
@@ -74,8 +74,8 @@ public class OAuthConfiguration {
 	 * 
 	 * @return the token strategy
 	 */
-	public TokenStrategy getTokenStrategy() {
-		return tokenStrategy;
+	public IJaxTokenStrategy getTokenStrategy() {
+		return jaxTokenStrategy;
 	}
 
 	/**
@@ -83,9 +83,23 @@ public class OAuthConfiguration {
 	 * 
 	 * @param tokenStrategy the strategy
 	 */
-	public void setTokenStrategy(TokenStrategy tokenStrategy) {
+	public void setTokenStrategy(IJaxTokenStrategy tokenStrategy) {
+		this.jaxTokenStrategy = tokenStrategy;
+	}
+
+	public TokenStrategy getLegacyTokenStrategy() {
+		return tokenStrategy;
+	}
+
+	/**
+	 * Sets the strategy used to generate and verify OAuth tokens.
+	 *
+	 * @param tokenStrategy the strategy
+	 */
+	public void setLegacyTokenStrategy(TokenStrategy tokenStrategy) {
 		this.tokenStrategy = tokenStrategy;
 	}
+
 
 	/**
 	 * Gets the store used for managing consumers.

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthRequest.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthRequest.java
@@ -13,9 +13,14 @@ package org.eclipse.lyo.server.oauth.core;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.ws.rs.core.MultivaluedMap;
 
 import net.oauth.OAuth;
 import net.oauth.OAuthAccessor;
@@ -71,15 +76,58 @@ public class OAuthRequest {
 		String token = this.message.getToken();
 		if (token != null) {
 			this.accessor.tokenSecret = OAuthConfiguration.getInstance()
-					.getTokenStrategy().getTokenSecret(this.httpRequest, token);
+					.getTokenStrategy().getTokenSecret(token);
 		}
 	}
-	
+
+	public static class OAuthServletRequestWrapper extends HttpServletRequestWrapper {
+
+		private final Map<String, String[]> formParams;
+
+		/**
+		 * Constructs a request object wrapping the given request.
+		 *
+		 * @param request
+		 * @throws IllegalArgumentException if the request is null
+		 */
+		public OAuthServletRequestWrapper(HttpServletRequest request,
+										  MultivaluedMap<String, String> formParams) {
+			super(request);
+			this.formParams = aggregateMultimap(formParams);
+		}
+
+		private Map<String, String[]> aggregateMultimap(MultivaluedMap<String, String> multimap) {
+			HashMap<String, String[]> map = new HashMap<>();
+			multimap.forEach((key, strings) -> map.put(key, strings.toArray(new String[0])));
+			return map;
+		}
+
+		@Override
+		public String getParameter(String name) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Map<String, String[]> getParameterMap() {
+			return formParams;
+		}
+
+		@Override
+		public Enumeration<String> getParameterNames() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String[] getParameterValues(String name) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
 	public HttpServletRequest getHttpRequest() {
 		return httpRequest;
 	}
 
-	public void setHttpRequest(HttpServletRequest httpRequest) {
+	private void setHttpRequest(HttpServletRequest httpRequest) {
 		this.httpRequest = httpRequest;
 	}
 

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/IJaxTokenStrategy.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/IJaxTokenStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 KTH Royal Institute of Technology and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.lyo.server.oauth.core.token;
+
+import net.oauth.OAuthMessage;
+import net.oauth.OAuthProblemException;
+import org.eclipse.lyo.server.oauth.core.OAuthRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public interface IJaxTokenStrategy {
+    void generateRequestToken(OAuthRequest oAuthRequest) throws IOException;
+    void validateVerificationCode(OAuthRequest oAuthRequest) throws IOException, OAuthProblemException;
+    void generateAccessToken(OAuthRequest oAuthRequest) throws OAuthProblemException, IOException;
+
+    String validateRequestToken(OAuthMessage message) throws IOException, OAuthProblemException;
+    String getCallback(String requestToken) throws OAuthProblemException;
+    void markRequestTokenAuthorized(HttpServletRequest httpRequest, String requestToken) throws OAuthProblemException;
+    String generateVerificationCode(String requestToken) throws OAuthProblemException;
+    String getTokenSecret(String secretToken) throws OAuthProblemException;
+
+    void validateAccessToken(OAuthRequest oAuthRequest) throws IOException, OAuthProblemException;
+}

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/JaxTokenStrategy.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/JaxTokenStrategy.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2019 KTH Royal Institute of Technology and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.lyo.server.oauth.core.token;
+
+import net.oauth.OAuth;
+import net.oauth.OAuthAccessor;
+import net.oauth.OAuthMessage;
+import net.oauth.OAuthProblemException;
+import org.eclipse.lyo.server.oauth.core.OAuthRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.Map;
+
+public class JaxTokenStrategy implements IJaxTokenStrategy {
+    // key is request token string, value is RequestTokenData
+    private final Map<String, RequestTokenData> requestTokens;
+
+    // key is access token, value is consumer key
+    private final Map<String, String> accessTokens;
+
+    // key is token, value is token secret
+    private final Map<String, String> tokenSecrets;
+
+    public JaxTokenStrategy(int requestTokenMaxCount, int accessTokenMaxCount) {
+        requestTokens = new LRUCache<>(requestTokenMaxCount);
+        accessTokens = new LRUCache<>(accessTokenMaxCount);
+        tokenSecrets = new LRUCache<>(requestTokenMaxCount + accessTokenMaxCount);
+    }
+
+    @Override
+    public void generateRequestToken(OAuthRequest oAuthRequest) throws IOException {
+        OAuthAccessor accessor = oAuthRequest.getAccessor();
+        accessor.requestToken = StrategyUtil.generateTokenString();
+        accessor.tokenSecret = StrategyUtil.generateTokenString();
+        String callback = oAuthRequest.getMessage()
+                .getParameter(OAuth.OAUTH_CALLBACK);
+        synchronized (requestTokens) {
+            requestTokens.put(accessor.requestToken, new RequestTokenData(
+                    accessor.consumer.consumerKey, callback));
+        }
+        synchronized (tokenSecrets) {
+            tokenSecrets.put(accessor.requestToken, accessor.tokenSecret);
+        }
+    }
+
+    @Override
+    public void validateVerificationCode(OAuthRequest oAuthRequest) throws IOException, OAuthProblemException {
+        String verificationCode = oAuthRequest.getMessage().getParameter(
+                OAuth.OAUTH_VERIFIER);
+        if (verificationCode == null) {
+            throw new OAuthProblemException(
+                    OAuth.Problems.OAUTH_PARAMETERS_ABSENT);
+        }
+
+        RequestTokenData tokenData = getRequestTokenData(oAuthRequest);
+        if (!verificationCode.equals(tokenData.getVerificationCode())) {
+            throw new OAuthProblemException(
+                    OAuth.Problems.OAUTH_PARAMETERS_REJECTED);
+        }
+
+    }
+
+    @Override
+    public void generateAccessToken(OAuthRequest oAuthRequest) throws OAuthProblemException, IOException {
+        // Remove the old request token.
+        OAuthAccessor accessor = oAuthRequest.getAccessor();
+        String requestToken = oAuthRequest.getMessage().getToken();
+        synchronized (requestTokens) {
+            if (!isRequestTokenAuthorized(requestToken)) {
+                throw new OAuthProblemException(
+                        OAuth.Problems.ADDITIONAL_AUTHORIZATION_REQUIRED);
+            }
+
+            requestTokens.remove(requestToken);
+        }
+
+        // Generate a new access token.
+        accessor.accessToken = StrategyUtil.generateTokenString();
+        synchronized (accessTokens) {
+            accessTokens.put(accessor.accessToken,
+                    accessor.consumer.consumerKey);
+        }
+
+        // Remove the old token secret and create a new one for this access
+        // token.
+        accessor.tokenSecret = StrategyUtil.generateTokenString();
+        synchronized (tokenSecrets) {
+            tokenSecrets.remove(requestToken);
+            tokenSecrets.put(accessor.accessToken, accessor.tokenSecret);
+        }
+
+        accessor.requestToken = null;
+
+    }
+
+    private boolean isRequestTokenAuthorized(String requestToken) throws OAuthProblemException {
+        return getRequestTokenData(requestToken).isAuthorized();
+    }
+
+
+    @Override
+    public String validateRequestToken(OAuthMessage message) throws IOException, OAuthProblemException {
+        return getRequestTokenData(message.getToken()).getConsumerKey();
+    }
+
+    @Override
+    public String getCallback(String requestToken) throws OAuthProblemException {
+        return getRequestTokenData(requestToken).getCallback();
+    }
+
+    @Override
+    public void markRequestTokenAuthorized(HttpServletRequest httpRequest, String requestToken)
+            throws OAuthProblemException {
+        getRequestTokenData(requestToken).setAuthorized(true);
+    }
+
+    @Override
+    public String generateVerificationCode(String requestToken) throws OAuthProblemException {
+        String verificationCode = StrategyUtil.generateTokenString();
+        getRequestTokenData(requestToken).setVerificationCode(verificationCode);
+
+        return verificationCode;
+    }
+
+    @Override
+    public String getTokenSecret(String token) throws OAuthProblemException {
+        synchronized (tokenSecrets) {
+            String tokenSecret = tokenSecrets.get(token);
+            if (tokenSecret == null) {
+                // It's possible the token secret was purged from the LRU cache,
+                // or the token is just not recognized. Either way, we can
+                // consider the token rejected.
+                throw new OAuthProblemException(OAuth.Problems.TOKEN_REJECTED);
+            }
+            return tokenSecret;
+        }
+    }
+
+    @Override
+    public void validateAccessToken(OAuthRequest oAuthRequest) throws IOException, OAuthProblemException {
+        synchronized (accessTokens) {
+            String actualValue = accessTokens.get(oAuthRequest.getMessage().getToken());
+            if (!oAuthRequest.getConsumer().consumerKey.equals(actualValue)) {
+                throw new OAuthProblemException(OAuth.Problems.TOKEN_REJECTED);
+            }
+        }
+    }
+
+    /**
+     * Gets the request token data from this OAuth request.
+     *
+     * @param oAuthRequest
+     *            the OAuth request
+     * @return the request token data
+     * @throws OAuthProblemException
+     *             if the request token is invalid
+     * @throws IOException
+     *             on reading OAuth parameters
+     */
+    protected RequestTokenData getRequestTokenData(OAuthRequest oAuthRequest)
+            throws OAuthProblemException, IOException {
+        return getRequestTokenData(oAuthRequest.getMessage().getToken());
+    }
+
+    /**
+     * Gets the request token data for this request token.
+     *
+     * @param requestToken
+     *            the request token string
+     * @return the request token data
+     * @throws OAuthProblemException
+     *             if the request token is invalid
+     */
+    protected RequestTokenData getRequestTokenData(String requestToken)
+            throws OAuthProblemException {
+        synchronized (requestTokens) {
+            RequestTokenData tokenData = requestTokens.get(requestToken);
+            if (tokenData == null) {
+                throw new OAuthProblemException(OAuth.Problems.TOKEN_REJECTED);
+            }
+            return tokenData;
+        }
+    }
+}

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/RequestTokenData.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/RequestTokenData.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012-2019 IBM Corporation and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.lyo.server.oauth.core.token;
+
+/**
+ * Holds information associated with a request token such as the callback
+ * URL and OAuth verification code.
+ *
+ * @author Samuel Padgett
+ */
+class RequestTokenData {
+    private String consumerKey;
+    private boolean authorized;
+    private String callback;
+    private String verificationCode;
+
+    public RequestTokenData(String consumerKey) {
+        this.consumerKey = consumerKey;
+        this.authorized = false;
+        this.callback = null;
+    }
+
+    public RequestTokenData(String consumerKey, String callback) {
+        this.consumerKey = consumerKey;
+        this.authorized = false;
+        this.callback = callback;
+    }
+
+    public String getConsumerKey() {
+        return consumerKey;
+    }
+
+    public void setConsumerKey(String consumerKey) {
+        this.consumerKey = consumerKey;
+    }
+
+    public boolean isAuthorized() {
+        return authorized;
+    }
+
+    public void setAuthorized(boolean authorized) {
+        this.authorized = authorized;
+    }
+
+    public String getCallback() {
+        return callback;
+    }
+
+    public void setCallback(String callback) {
+        this.callback = callback;
+    }
+
+    public String getVerificationCode() {
+        return verificationCode;
+    }
+
+    public void setVerificationCode(String verificationCode) {
+        this.verificationCode = verificationCode;
+    }
+}

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/SimpleTokenStrategy.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/SimpleTokenStrategy.java
@@ -1,23 +1,18 @@
-/*******************************************************************************
- * Copyright (c) 2012 IBM Corporation.
+/*
+ * Copyright (c) 2012-2019 IBM Corporation and others
  *
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Eclipse Distribution License v. 1.0 which accompanies this distribution.
- *  
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Eclipse Distribution License is available at
- *  http://www.eclipse.org/org/documents/edl-v10.php.
- *  
- *  Contributors:
- *  
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
 package org.eclipse.lyo.server.oauth.core.token;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -40,64 +35,7 @@ import net.oauth.OAuthProblemException;
 public class SimpleTokenStrategy implements TokenStrategy {
 	private final static int REQUEST_TOKEN_MAX_ENTIRES = 500;
 	private final static int ACCESS_TOKEN_MAX_ENTRIES = 5000;
-	
-	/**
-	 * Holds information associated with a request token such as the callback
-	 * URL and OAuth verification code.
-	 * 
-	 * @author Samuel Padgett
-	 */
-	protected class RequestTokenData {
-		private String consumerKey;
-		private boolean authorized;
-		private String callback;
-		private String verificationCode;
-		
-		public RequestTokenData(String consumerKey) {
-			this.consumerKey = consumerKey;
-			this.authorized = false;
-			this.callback = null;
-		}
 
-		public RequestTokenData(String consumerKey, String callback) {
-			this.consumerKey = consumerKey;
-			this.authorized = false;
-			this.callback = callback;
-		}
-		
-		public String getConsumerKey() {
-			return consumerKey;
-		}
-		
-		public void setConsumerKey(String consumerKey) {
-			this.consumerKey = consumerKey;
-		}
-		
-		public boolean isAuthorized() {
-			return authorized;
-		}
-		
-		public void setAuthorized(boolean authorized) {
-			this.authorized = authorized;
-		}
-		
-		public String getCallback() {
-			return callback;
-		}
-		
-		public void setCallback(String callback) {
-			this.callback = callback;
-		}
-		
-		public String getVerificationCode() {
-			return verificationCode;
-		}
-		
-		public void setVerificationCode(String verificationCode) {
-			this.verificationCode = verificationCode;
-		}
-	}
-	
 	// key is request token string, value is RequestTokenData
 	private Map<String, RequestTokenData> requestTokens;
 
@@ -137,8 +75,8 @@ public class SimpleTokenStrategy implements TokenStrategy {
 	public void generateRequestToken(OAuthRequest oAuthRequest)
 			throws IOException {
 		OAuthAccessor accessor = oAuthRequest.getAccessor();
-		accessor.requestToken = generateTokenString();
-		accessor.tokenSecret = generateTokenString();
+		accessor.requestToken = StrategyUtil.generateTokenString();
+		accessor.tokenSecret = StrategyUtil.generateTokenString();
 		String callback = oAuthRequest.getMessage()
 				.getParameter(OAuth.OAUTH_CALLBACK);
 		synchronized (requestTokens) {
@@ -177,7 +115,7 @@ public class SimpleTokenStrategy implements TokenStrategy {
 	@Override
 	public String generateVerificationCode(HttpServletRequest httpRequest,
 			String requestToken) throws OAuthProblemException {
-		String verificationCode = generateTokenString();
+		String verificationCode = StrategyUtil.generateTokenString();
 		getRequestTokenData(requestToken).setVerificationCode(verificationCode);
 		
 		return verificationCode;
@@ -217,7 +155,7 @@ public class SimpleTokenStrategy implements TokenStrategy {
 		}
 
 		// Generate a new access token.
-		accessor.accessToken = generateTokenString();
+		accessor.accessToken = StrategyUtil.generateTokenString();
 		synchronized (accessTokens) {
 			accessTokens.put(accessor.accessToken,
 					accessor.consumer.consumerKey);
@@ -225,7 +163,7 @@ public class SimpleTokenStrategy implements TokenStrategy {
 
 		// Remove the old token secret and create a new one for this access
 		// token.
-		accessor.tokenSecret = generateTokenString();
+		accessor.tokenSecret = StrategyUtil.generateTokenString();
 		synchronized (tokenSecrets) {
 			tokenSecrets.remove(requestToken);
 			tokenSecrets.put(accessor.accessToken, accessor.tokenSecret);
@@ -259,15 +197,6 @@ public class SimpleTokenStrategy implements TokenStrategy {
 			}
 			return tokenSecret;
 		}
-	}
-	
-	/**
-	 * Creates a unique, random string to use for tokens.
-	 * 
-	 * @return the random string
-	 */
-	protected String generateTokenString() {
-		return UUID.randomUUID().toString();
 	}
 
 	/**

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/StrategyUtil.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/StrategyUtil.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 KTH Royal Institute of Technology and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.lyo.server.oauth.core.token;
+
+import java.util.UUID;
+
+public class StrategyUtil {
+    /**
+     * Creates a unique, random string to use for tokens.
+     *
+     * @return the random string
+     */
+    public static String generateTokenString() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/TokenStrategy.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/TokenStrategy.java
@@ -25,9 +25,12 @@ import org.eclipse.lyo.server.oauth.core.OAuthRequest;
  * Manages and validates OAuth tokens and token secrets.
  * {@link SimpleTokenStrategy} is a basic implementation, but you can implement
  * this interface to generate and validate OAuth tokens your own way.
+ *
+ * <p><b>Deprecated due to not using JAX-RS inputs. Broken in Jersey.</b></p>
  * 
  * @author Samuel Padgett
  */
+@Deprecated
 public interface TokenStrategy {
 	/**
 	 * Generates a request token and token secret and sets it in the accessor in

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation.
+/*
+ * Copyright (c) 2012-2019 IBM Corporation and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,13 +8,7 @@
  * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
  * and the Eclipse Distribution License is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * Contributors:
- *
- *     Michael Fiedler     - initial API and implementation for Bugzilla adapter
- *     Susumu Fukuda       - extracted this class from Bugzilla adapter CredentialsFilter
- *     Samuel Padgett      - fix NPEx when Exception.getCause() returns null in Application.login()
- *******************************************************************************/
+ */
 package org.eclipse.lyo.server.oauth.core.utils;
 
 import java.io.IOException;
@@ -47,8 +41,8 @@ import org.eclipse.lyo.server.oauth.core.OAuthConfiguration;
 import org.eclipse.lyo.server.oauth.core.OAuthRequest;
 import org.eclipse.lyo.server.oauth.core.consumer.ConsumerStore;
 import org.eclipse.lyo.server.oauth.core.consumer.LyoOAuthConsumer;
+import org.eclipse.lyo.server.oauth.core.token.JaxTokenStrategy;
 import org.eclipse.lyo.server.oauth.core.token.LRUCache;
-import org.eclipse.lyo.server.oauth.core.token.SimpleTokenStrategy;
 
 /**
  * <h3>Overview</h3>
@@ -448,7 +442,7 @@ abstract public class AbstractAdapterCredentialsFilter<Credentials, Connection> 
 		 * Override some SimpleTokenStrategy methods so that we can keep the
 		 * Connector associated with the OAuth tokens.
 		 */
-		config.setTokenStrategy(new SimpleTokenStrategy() {
+		config.setTokenStrategy(new JaxTokenStrategy(128, 4096) {
 			@SuppressWarnings("unchecked")
 			@Override
 			public void markRequestTokenAuthorized(


### PR DESCRIPTION
Depending on the configuration of the JAX-RS application, especially under Jersey, POST parameters may not be readable from the `HttpServletRequest` and shall be accessed through JAX-RS facilities instead. See https://stackoverflow.com/questions/22376810/unable-to-retrieve-post-data-using-context-httpservletrequest-when-passed-to-o for more details.

While I defined a new interface `IJaxTokenStrategy` that does not depend on the `HttpServletRequest`, the key method `net.oauth.server.HttpRequestMessage#getParameters` does and is outside of our control. Therefore, `OAuthRequest.OAuthServletRequestWrapper` class has been defined to wrap the original request while substituting the parameter map.

Given that `OAuthRequest` already provides a reference to the `HttpServletRequest`, I decided not to remove the newly created interface. 