### PR TITLE
Detect Lyo URI and correctly pass POST parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## 4.0.0 (WIP)
 
+### Added
+
+- `OAuthRequest` can now detect configured server URI via `OSLC4JUtils`
+
 ### Changed
 
 - `HTTPConstants` is no longer a public class
 - `ServletListener` was renamed to `OAuthServletListener`
-

--- a/oauth-core/pom.xml
+++ b/oauth-core/pom.xml
@@ -20,7 +20,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <lyo.version>${project.parent.version}</lyo.version>
     </properties>
 
     <repositories>
@@ -43,6 +42,12 @@
         <dependency>
             <groupId>net.oauth.core</groupId>
             <artifactId>oauth-provider</artifactId>
+        </dependency>
+
+        <!-- Lyo -->
+        <dependency>
+            <groupId>org.eclipse.lyo.oslc4j.core</groupId>
+            <artifactId>oslc4j-core</artifactId>
         </dependency>
 
         <!-- Generic -->

--- a/oauth-core/pom.xml
+++ b/oauth-core/pom.xml
@@ -47,10 +47,15 @@
 
         <!-- Generic -->
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.servlet</artifactId>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+
 
         <!-- Test -->
         <dependency>

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthConfiguration.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthConfiguration.java
@@ -74,7 +74,7 @@ public class OAuthConfiguration {
 	 * 
 	 * @return the token strategy
 	 */
-	public IJaxTokenStrategy getTokenStrategy() {
+	public IJaxTokenStrategy getJaxTokenStrategy() {
 		return jaxTokenStrategy;
 	}
 
@@ -83,11 +83,15 @@ public class OAuthConfiguration {
 	 * 
 	 * @param tokenStrategy the strategy
 	 */
-	public void setTokenStrategy(IJaxTokenStrategy tokenStrategy) {
+	public void setJaxTokenStrategy(IJaxTokenStrategy tokenStrategy) {
 		this.jaxTokenStrategy = tokenStrategy;
 	}
 
-	public TokenStrategy getLegacyTokenStrategy() {
+    /**
+     * See {@link #getJaxTokenStrategy()}
+     * @return
+     */
+	public TokenStrategy getTokenStrategy() {
 		return tokenStrategy;
 	}
 
@@ -96,7 +100,7 @@ public class OAuthConfiguration {
 	 *
 	 * @param tokenStrategy the strategy
 	 */
-	public void setLegacyTokenStrategy(TokenStrategy tokenStrategy) {
+	public void setTokenStrategy(TokenStrategy tokenStrategy) {
 		this.tokenStrategy = tokenStrategy;
 	}
 

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthConfiguration.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthConfiguration.java
@@ -1,18 +1,14 @@
-/*******************************************************************************
- * Copyright (c) 2012 IBM Corporation.
+/*
+ * Copyright (c) 2012-2019 IBM Corporation and others
  *
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Eclipse Distribution License v. 1.0 which accompanies this distribution.
- *  
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Eclipse Distribution License is available at
- *  http://www.eclipse.org/org/documents/edl-v10.php.
- *  
- *  Contributors:
- *  
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
 package org.eclipse.lyo.server.oauth.core;
 
 import javax.servlet.http.HttpServletResponse;
@@ -24,6 +20,8 @@ import net.oauth.http.HttpMessage;
 
 import org.eclipse.lyo.server.oauth.core.consumer.ConsumerStore;
 import org.eclipse.lyo.server.oauth.core.consumer.ConsumerStoreException;
+import org.eclipse.lyo.server.oauth.core.token.IJaxTokenStrategy;
+import org.eclipse.lyo.server.oauth.core.token.JaxTokenStrategy;
 import org.eclipse.lyo.server.oauth.core.token.SimpleTokenStrategy;
 import org.eclipse.lyo.server.oauth.core.token.TokenStrategy;
 
@@ -36,6 +34,7 @@ import org.eclipse.lyo.server.oauth.core.token.TokenStrategy;
 public class OAuthConfiguration {
 	private OAuthValidator validator;
 	private TokenStrategy tokenStrategy;
+	private IJaxTokenStrategy jaxTokenStrategy;
 	private ConsumerStore consumerStore = null;
 	private Application application = null;
 	private boolean v1_0Allowed = true;
@@ -49,6 +48,7 @@ public class OAuthConfiguration {
 	private OAuthConfiguration() {
 		validator = new SimpleOAuthValidator();
 		tokenStrategy = new SimpleTokenStrategy();
+		jaxTokenStrategy = new JaxTokenStrategy(128, 1024);
 	}
 
 	/**
@@ -74,8 +74,8 @@ public class OAuthConfiguration {
 	 * 
 	 * @return the token strategy
 	 */
-	public TokenStrategy getTokenStrategy() {
-		return tokenStrategy;
+	public IJaxTokenStrategy getTokenStrategy() {
+		return jaxTokenStrategy;
 	}
 
 	/**
@@ -83,9 +83,23 @@ public class OAuthConfiguration {
 	 * 
 	 * @param tokenStrategy the strategy
 	 */
-	public void setTokenStrategy(TokenStrategy tokenStrategy) {
+	public void setTokenStrategy(IJaxTokenStrategy tokenStrategy) {
+		this.jaxTokenStrategy = tokenStrategy;
+	}
+
+	public TokenStrategy getLegacyTokenStrategy() {
+		return tokenStrategy;
+	}
+
+	/**
+	 * Sets the strategy used to generate and verify OAuth tokens.
+	 *
+	 * @param tokenStrategy the strategy
+	 */
+	public void setLegacyTokenStrategy(TokenStrategy tokenStrategy) {
 		this.tokenStrategy = tokenStrategy;
 	}
+
 
 	/**
 	 * Gets the store used for managing consumers.

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthRequest.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthRequest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
+import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MultivaluedMap;
 
 import net.oauth.OAuth;
@@ -31,6 +32,7 @@ import net.oauth.OAuthProblemException;
 import net.oauth.OAuthValidator;
 import net.oauth.server.OAuthServlet;
 
+import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
 import org.eclipse.lyo.server.oauth.core.consumer.LyoOAuthConsumer;
 
 /**
@@ -58,11 +60,29 @@ public class OAuthRequest {
 	private HttpServletRequest httpRequest;
 	private OAuthMessage message;
 	private OAuthAccessor accessor;
-	
+
+	/**
+	 * Use {@link #OAuthRequest(HttpServletRequest, boolean)} instead.
+	 */
+	@Deprecated
 	public OAuthRequest(HttpServletRequest request)
 			throws OAuthException, IOException {
+		// preserving legacy behaviour
+		this(request, false);
+	}
+
+	/**
+	 * @param detectLyoURI Determines if {@link OSLC4JUtils#resolveFullUri(HttpServletRequest)} shall
+	 *                     be used.
+	 * @throws OAuthException OAuth request is invalid
+	 */
+	public OAuthRequest(HttpServletRequest request, boolean detectLyoURI) throws OAuthException, IOException {
 		this.httpRequest = request;
-		this.message = OAuthServlet.getMessage(httpRequest, null);
+		String fullUrl = null;
+		if (detectLyoURI) {
+			fullUrl = OSLC4JUtils.resolveFullUri(request);
+		}
+		this.message = OAuthServlet.getMessage(httpRequest, fullUrl);
 
 		LyoOAuthConsumer consumer = OAuthConfiguration.getInstance()
 				.getConsumerStore().getConsumer(message);

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthRequest.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthRequest.java
@@ -13,6 +13,7 @@ package org.eclipse.lyo.server.oauth.core;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -76,7 +77,7 @@ public class OAuthRequest {
 		String token = this.message.getToken();
 		if (token != null) {
 			this.accessor.tokenSecret = OAuthConfiguration.getInstance()
-					.getTokenStrategy().getTokenSecret(token);
+					.getJaxTokenStrategy().getTokenSecret(token);
 		}
 	}
 
@@ -160,7 +161,7 @@ public class OAuthRequest {
 		try {
 			OAuthConfiguration config = OAuthConfiguration.getInstance();
 			config.getValidator().validateMessage(message, accessor);
-			config.getTokenStrategy().validateAccessToken(this);
+			config.getJaxTokenStrategy().validateAccessToken(this);
 		} catch (URISyntaxException e) {
 			throw new ServletException(e);
 		}

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthRequest.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthRequest.java
@@ -13,9 +13,14 @@ package org.eclipse.lyo.server.oauth.core;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.ws.rs.core.MultivaluedMap;
 
 import net.oauth.OAuth;
 import net.oauth.OAuthAccessor;
@@ -71,15 +76,58 @@ public class OAuthRequest {
 		String token = this.message.getToken();
 		if (token != null) {
 			this.accessor.tokenSecret = OAuthConfiguration.getInstance()
-					.getTokenStrategy().getTokenSecret(this.httpRequest, token);
+					.getTokenStrategy().getTokenSecret(token);
 		}
 	}
-	
+
+	public static class OAuthServletRequestWrapper extends HttpServletRequestWrapper {
+
+		private final Map<String, String[]> formParams;
+
+		/**
+		 * Constructs a request object wrapping the given request.
+		 *
+		 * @param request
+		 * @throws IllegalArgumentException if the request is null
+		 */
+		public OAuthServletRequestWrapper(HttpServletRequest request,
+										  MultivaluedMap<String, String> formParams) {
+			super(request);
+			this.formParams = aggregateMultimap(formParams);
+		}
+
+		private Map<String, String[]> aggregateMultimap(MultivaluedMap<String, String> multimap) {
+			HashMap<String, String[]> map = new HashMap<>();
+			multimap.forEach((key, strings) -> map.put(key, strings.toArray(new String[0])));
+			return map;
+		}
+
+		@Override
+		public String getParameter(String name) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Map<String, String[]> getParameterMap() {
+			return formParams;
+		}
+
+		@Override
+		public Enumeration<String> getParameterNames() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String[] getParameterValues(String name) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
 	public HttpServletRequest getHttpRequest() {
 		return httpRequest;
 	}
 
-	public void setHttpRequest(HttpServletRequest httpRequest) {
+	private void setHttpRequest(HttpServletRequest httpRequest) {
 		this.httpRequest = httpRequest;
 	}
 

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthRequest.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/OAuthRequest.java
@@ -105,7 +105,11 @@ public class OAuthRequest {
 
 		@Override
 		public String getParameter(String name) {
-			throw new UnsupportedOperationException();
+			String[] values = formParams.get(name);
+			if (values == null || values.length == 0) {
+				return null;
+			}
+			return values[0];
 		}
 
 		@Override
@@ -115,12 +119,12 @@ public class OAuthRequest {
 
 		@Override
 		public Enumeration<String> getParameterNames() {
-			throw new UnsupportedOperationException();
+			return Collections.enumeration(formParams.keySet());
 		}
 
 		@Override
 		public String[] getParameterValues(String name) {
-			throw new UnsupportedOperationException();
+			return formParams.get(name);
 		}
 	}
 

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/IJaxTokenStrategy.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/IJaxTokenStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 KTH Royal Institute of Technology and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.lyo.server.oauth.core.token;
+
+import net.oauth.OAuthMessage;
+import net.oauth.OAuthProblemException;
+import org.eclipse.lyo.server.oauth.core.OAuthRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public interface IJaxTokenStrategy {
+    void generateRequestToken(OAuthRequest oAuthRequest) throws IOException;
+    void validateVerificationCode(OAuthRequest oAuthRequest) throws IOException, OAuthProblemException;
+    void generateAccessToken(OAuthRequest oAuthRequest) throws OAuthProblemException, IOException;
+
+    String validateRequestToken(OAuthMessage message) throws IOException, OAuthProblemException;
+    String getCallback(String requestToken) throws OAuthProblemException;
+    void markRequestTokenAuthorized(HttpServletRequest httpRequest, String requestToken) throws OAuthProblemException;
+    String generateVerificationCode(String requestToken) throws OAuthProblemException;
+    String getTokenSecret(String secretToken) throws OAuthProblemException;
+
+    void validateAccessToken(OAuthRequest oAuthRequest) throws IOException, OAuthProblemException;
+}

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/JaxTokenStrategy.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/JaxTokenStrategy.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2019 KTH Royal Institute of Technology and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.lyo.server.oauth.core.token;
+
+import net.oauth.OAuth;
+import net.oauth.OAuthAccessor;
+import net.oauth.OAuthMessage;
+import net.oauth.OAuthProblemException;
+import org.eclipse.lyo.server.oauth.core.OAuthRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.Map;
+
+public class JaxTokenStrategy implements IJaxTokenStrategy {
+    // key is request token string, value is RequestTokenData
+    private final Map<String, RequestTokenData> requestTokens;
+
+    // key is access token, value is consumer key
+    private final Map<String, String> accessTokens;
+
+    // key is token, value is token secret
+    private final Map<String, String> tokenSecrets;
+
+    public JaxTokenStrategy(int requestTokenMaxCount, int accessTokenMaxCount) {
+        requestTokens = new LRUCache<>(requestTokenMaxCount);
+        accessTokens = new LRUCache<>(accessTokenMaxCount);
+        tokenSecrets = new LRUCache<>(requestTokenMaxCount + accessTokenMaxCount);
+    }
+
+    @Override
+    public void generateRequestToken(OAuthRequest oAuthRequest) throws IOException {
+        OAuthAccessor accessor = oAuthRequest.getAccessor();
+        accessor.requestToken = StrategyUtil.generateTokenString();
+        accessor.tokenSecret = StrategyUtil.generateTokenString();
+        String callback = oAuthRequest.getMessage()
+                .getParameter(OAuth.OAUTH_CALLBACK);
+        synchronized (requestTokens) {
+            requestTokens.put(accessor.requestToken, new RequestTokenData(
+                    accessor.consumer.consumerKey, callback));
+        }
+        synchronized (tokenSecrets) {
+            tokenSecrets.put(accessor.requestToken, accessor.tokenSecret);
+        }
+    }
+
+    @Override
+    public void validateVerificationCode(OAuthRequest oAuthRequest) throws IOException, OAuthProblemException {
+        String verificationCode = oAuthRequest.getMessage().getParameter(
+                OAuth.OAUTH_VERIFIER);
+        if (verificationCode == null) {
+            throw new OAuthProblemException(
+                    OAuth.Problems.OAUTH_PARAMETERS_ABSENT);
+        }
+
+        RequestTokenData tokenData = getRequestTokenData(oAuthRequest);
+        if (!verificationCode.equals(tokenData.getVerificationCode())) {
+            throw new OAuthProblemException(
+                    OAuth.Problems.OAUTH_PARAMETERS_REJECTED);
+        }
+
+    }
+
+    @Override
+    public void generateAccessToken(OAuthRequest oAuthRequest) throws OAuthProblemException, IOException {
+        // Remove the old request token.
+        OAuthAccessor accessor = oAuthRequest.getAccessor();
+        String requestToken = oAuthRequest.getMessage().getToken();
+        synchronized (requestTokens) {
+            if (!isRequestTokenAuthorized(requestToken)) {
+                throw new OAuthProblemException(
+                        OAuth.Problems.ADDITIONAL_AUTHORIZATION_REQUIRED);
+            }
+
+            requestTokens.remove(requestToken);
+        }
+
+        // Generate a new access token.
+        accessor.accessToken = StrategyUtil.generateTokenString();
+        synchronized (accessTokens) {
+            accessTokens.put(accessor.accessToken,
+                    accessor.consumer.consumerKey);
+        }
+
+        // Remove the old token secret and create a new one for this access
+        // token.
+        accessor.tokenSecret = StrategyUtil.generateTokenString();
+        synchronized (tokenSecrets) {
+            tokenSecrets.remove(requestToken);
+            tokenSecrets.put(accessor.accessToken, accessor.tokenSecret);
+        }
+
+        accessor.requestToken = null;
+
+    }
+
+    private boolean isRequestTokenAuthorized(String requestToken) throws OAuthProblemException {
+        return getRequestTokenData(requestToken).isAuthorized();
+    }
+
+
+    @Override
+    public String validateRequestToken(OAuthMessage message) throws IOException, OAuthProblemException {
+        return getRequestTokenData(message.getToken()).getConsumerKey();
+    }
+
+    @Override
+    public String getCallback(String requestToken) throws OAuthProblemException {
+        return getRequestTokenData(requestToken).getCallback();
+    }
+
+    @Override
+    public void markRequestTokenAuthorized(HttpServletRequest httpRequest, String requestToken)
+            throws OAuthProblemException {
+        getRequestTokenData(requestToken).setAuthorized(true);
+    }
+
+    @Override
+    public String generateVerificationCode(String requestToken) throws OAuthProblemException {
+        String verificationCode = StrategyUtil.generateTokenString();
+        getRequestTokenData(requestToken).setVerificationCode(verificationCode);
+
+        return verificationCode;
+    }
+
+    @Override
+    public String getTokenSecret(String token) throws OAuthProblemException {
+        synchronized (tokenSecrets) {
+            String tokenSecret = tokenSecrets.get(token);
+            if (tokenSecret == null) {
+                // It's possible the token secret was purged from the LRU cache,
+                // or the token is just not recognized. Either way, we can
+                // consider the token rejected.
+                throw new OAuthProblemException(OAuth.Problems.TOKEN_REJECTED);
+            }
+            return tokenSecret;
+        }
+    }
+
+    @Override
+    public void validateAccessToken(OAuthRequest oAuthRequest) throws IOException, OAuthProblemException {
+        synchronized (accessTokens) {
+            String actualValue = accessTokens.get(oAuthRequest.getMessage().getToken());
+            if (!oAuthRequest.getConsumer().consumerKey.equals(actualValue)) {
+                throw new OAuthProblemException(OAuth.Problems.TOKEN_REJECTED);
+            }
+        }
+    }
+
+    /**
+     * Gets the request token data from this OAuth request.
+     *
+     * @param oAuthRequest
+     *            the OAuth request
+     * @return the request token data
+     * @throws OAuthProblemException
+     *             if the request token is invalid
+     * @throws IOException
+     *             on reading OAuth parameters
+     */
+    protected RequestTokenData getRequestTokenData(OAuthRequest oAuthRequest)
+            throws OAuthProblemException, IOException {
+        return getRequestTokenData(oAuthRequest.getMessage().getToken());
+    }
+
+    /**
+     * Gets the request token data for this request token.
+     *
+     * @param requestToken
+     *            the request token string
+     * @return the request token data
+     * @throws OAuthProblemException
+     *             if the request token is invalid
+     */
+    protected RequestTokenData getRequestTokenData(String requestToken)
+            throws OAuthProblemException {
+        synchronized (requestTokens) {
+            RequestTokenData tokenData = requestTokens.get(requestToken);
+            if (tokenData == null) {
+                throw new OAuthProblemException(OAuth.Problems.TOKEN_REJECTED);
+            }
+            return tokenData;
+        }
+    }
+}

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/RequestTokenData.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/RequestTokenData.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012-2019 IBM Corporation and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.lyo.server.oauth.core.token;
+
+/**
+ * Holds information associated with a request token such as the callback
+ * URL and OAuth verification code.
+ *
+ * @author Samuel Padgett
+ */
+class RequestTokenData {
+    private String consumerKey;
+    private boolean authorized;
+    private String callback;
+    private String verificationCode;
+
+    public RequestTokenData(String consumerKey) {
+        this.consumerKey = consumerKey;
+        this.authorized = false;
+        this.callback = null;
+    }
+
+    public RequestTokenData(String consumerKey, String callback) {
+        this.consumerKey = consumerKey;
+        this.authorized = false;
+        this.callback = callback;
+    }
+
+    public String getConsumerKey() {
+        return consumerKey;
+    }
+
+    public void setConsumerKey(String consumerKey) {
+        this.consumerKey = consumerKey;
+    }
+
+    public boolean isAuthorized() {
+        return authorized;
+    }
+
+    public void setAuthorized(boolean authorized) {
+        this.authorized = authorized;
+    }
+
+    public String getCallback() {
+        return callback;
+    }
+
+    public void setCallback(String callback) {
+        this.callback = callback;
+    }
+
+    public String getVerificationCode() {
+        return verificationCode;
+    }
+
+    public void setVerificationCode(String verificationCode) {
+        this.verificationCode = verificationCode;
+    }
+}

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/SimpleTokenStrategy.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/SimpleTokenStrategy.java
@@ -1,23 +1,18 @@
-/*******************************************************************************
- * Copyright (c) 2012 IBM Corporation.
+/*
+ * Copyright (c) 2012-2019 IBM Corporation and others
  *
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Eclipse Distribution License v. 1.0 which accompanies this distribution.
- *  
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Eclipse Distribution License is available at
- *  http://www.eclipse.org/org/documents/edl-v10.php.
- *  
- *  Contributors:
- *  
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
 package org.eclipse.lyo.server.oauth.core.token;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -40,64 +35,7 @@ import net.oauth.OAuthProblemException;
 public class SimpleTokenStrategy implements TokenStrategy {
 	private final static int REQUEST_TOKEN_MAX_ENTIRES = 500;
 	private final static int ACCESS_TOKEN_MAX_ENTRIES = 5000;
-	
-	/**
-	 * Holds information associated with a request token such as the callback
-	 * URL and OAuth verification code.
-	 * 
-	 * @author Samuel Padgett
-	 */
-	protected class RequestTokenData {
-		private String consumerKey;
-		private boolean authorized;
-		private String callback;
-		private String verificationCode;
-		
-		public RequestTokenData(String consumerKey) {
-			this.consumerKey = consumerKey;
-			this.authorized = false;
-			this.callback = null;
-		}
 
-		public RequestTokenData(String consumerKey, String callback) {
-			this.consumerKey = consumerKey;
-			this.authorized = false;
-			this.callback = callback;
-		}
-		
-		public String getConsumerKey() {
-			return consumerKey;
-		}
-		
-		public void setConsumerKey(String consumerKey) {
-			this.consumerKey = consumerKey;
-		}
-		
-		public boolean isAuthorized() {
-			return authorized;
-		}
-		
-		public void setAuthorized(boolean authorized) {
-			this.authorized = authorized;
-		}
-		
-		public String getCallback() {
-			return callback;
-		}
-		
-		public void setCallback(String callback) {
-			this.callback = callback;
-		}
-		
-		public String getVerificationCode() {
-			return verificationCode;
-		}
-		
-		public void setVerificationCode(String verificationCode) {
-			this.verificationCode = verificationCode;
-		}
-	}
-	
 	// key is request token string, value is RequestTokenData
 	private Map<String, RequestTokenData> requestTokens;
 
@@ -137,8 +75,8 @@ public class SimpleTokenStrategy implements TokenStrategy {
 	public void generateRequestToken(OAuthRequest oAuthRequest)
 			throws IOException {
 		OAuthAccessor accessor = oAuthRequest.getAccessor();
-		accessor.requestToken = generateTokenString();
-		accessor.tokenSecret = generateTokenString();
+		accessor.requestToken = StrategyUtil.generateTokenString();
+		accessor.tokenSecret = StrategyUtil.generateTokenString();
 		String callback = oAuthRequest.getMessage()
 				.getParameter(OAuth.OAUTH_CALLBACK);
 		synchronized (requestTokens) {
@@ -177,7 +115,7 @@ public class SimpleTokenStrategy implements TokenStrategy {
 	@Override
 	public String generateVerificationCode(HttpServletRequest httpRequest,
 			String requestToken) throws OAuthProblemException {
-		String verificationCode = generateTokenString();
+		String verificationCode = StrategyUtil.generateTokenString();
 		getRequestTokenData(requestToken).setVerificationCode(verificationCode);
 		
 		return verificationCode;
@@ -217,7 +155,7 @@ public class SimpleTokenStrategy implements TokenStrategy {
 		}
 
 		// Generate a new access token.
-		accessor.accessToken = generateTokenString();
+		accessor.accessToken = StrategyUtil.generateTokenString();
 		synchronized (accessTokens) {
 			accessTokens.put(accessor.accessToken,
 					accessor.consumer.consumerKey);
@@ -225,7 +163,7 @@ public class SimpleTokenStrategy implements TokenStrategy {
 
 		// Remove the old token secret and create a new one for this access
 		// token.
-		accessor.tokenSecret = generateTokenString();
+		accessor.tokenSecret = StrategyUtil.generateTokenString();
 		synchronized (tokenSecrets) {
 			tokenSecrets.remove(requestToken);
 			tokenSecrets.put(accessor.accessToken, accessor.tokenSecret);
@@ -259,15 +197,6 @@ public class SimpleTokenStrategy implements TokenStrategy {
 			}
 			return tokenSecret;
 		}
-	}
-	
-	/**
-	 * Creates a unique, random string to use for tokens.
-	 * 
-	 * @return the random string
-	 */
-	protected String generateTokenString() {
-		return UUID.randomUUID().toString();
 	}
 
 	/**

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/StrategyUtil.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/StrategyUtil.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 KTH Royal Institute of Technology and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.lyo.server.oauth.core.token;
+
+import java.util.UUID;
+
+public class StrategyUtil {
+    /**
+     * Creates a unique, random string to use for tokens.
+     *
+     * @return the random string
+     */
+    public static String generateTokenString() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/TokenStrategy.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/TokenStrategy.java
@@ -25,9 +25,12 @@ import org.eclipse.lyo.server.oauth.core.OAuthRequest;
  * Manages and validates OAuth tokens and token secrets.
  * {@link SimpleTokenStrategy} is a basic implementation, but you can implement
  * this interface to generate and validate OAuth tokens your own way.
+ *
+ * <p><b>Deprecated due to not using JAX-RS inputs. Broken in Jersey.</b></p>
  * 
  * @author Samuel Padgett
  */
+@Deprecated
 public interface TokenStrategy {
 	/**
 	 * Generates a request token and token secret and sets it in the accessor in

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation.
+/*
+ * Copyright (c) 2012-2019 IBM Corporation and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,13 +8,7 @@
  * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
  * and the Eclipse Distribution License is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * Contributors:
- *
- *     Michael Fiedler     - initial API and implementation for Bugzilla adapter
- *     Susumu Fukuda       - extracted this class from Bugzilla adapter CredentialsFilter
- *     Samuel Padgett      - fix NPEx when Exception.getCause() returns null in Application.login()
- *******************************************************************************/
+ */
 package org.eclipse.lyo.server.oauth.core.utils;
 
 import java.io.IOException;
@@ -47,8 +41,8 @@ import org.eclipse.lyo.server.oauth.core.OAuthConfiguration;
 import org.eclipse.lyo.server.oauth.core.OAuthRequest;
 import org.eclipse.lyo.server.oauth.core.consumer.ConsumerStore;
 import org.eclipse.lyo.server.oauth.core.consumer.LyoOAuthConsumer;
+import org.eclipse.lyo.server.oauth.core.token.JaxTokenStrategy;
 import org.eclipse.lyo.server.oauth.core.token.LRUCache;
-import org.eclipse.lyo.server.oauth.core.token.SimpleTokenStrategy;
 
 /**
  * <h3>Overview</h3>
@@ -448,7 +442,7 @@ abstract public class AbstractAdapterCredentialsFilter<Credentials, Connection> 
 		 * Override some SimpleTokenStrategy methods so that we can keep the
 		 * Connector associated with the OAuth tokens.
 		 */
-		config.setTokenStrategy(new SimpleTokenStrategy() {
+		config.setTokenStrategy(new JaxTokenStrategy(128, 4096) {
 			@SuppressWarnings("unchecked")
 			@Override
 			public void markRequestTokenAuthorized(

--- a/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
+++ b/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
@@ -442,7 +442,7 @@ abstract public class AbstractAdapterCredentialsFilter<Credentials, Connection> 
 		 * Override some SimpleTokenStrategy methods so that we can keep the
 		 * Connector associated with the OAuth tokens.
 		 */
-		config.setTokenStrategy(new JaxTokenStrategy(128, 4096) {
+		config.setJaxTokenStrategy(new JaxTokenStrategy(128, 4096) {
 			@SuppressWarnings("unchecked")
 			@Override
 			public void markRequestTokenAuthorized(

--- a/oauth-webapp/src/main/java/org/eclipse/lyo/server/oauth/webapp/services/OAuthService.java
+++ b/oauth-webapp/src/main/java/org/eclipse/lyo/server/oauth/webapp/services/OAuthService.java
@@ -92,7 +92,7 @@ public class OAuthService {
 			// Generate the token.
 			OAuthConfiguration.getInstance().getJaxTokenStrategy()
 					.generateRequestToken(oAuthRequest);
-			log.trace("Token generated");
+			log.debug("Request token generated");
 
 			// Check for OAuth 1.0a authentication.
 			boolean callbackConfirmed = confirmCallback(oAuthRequest);
@@ -102,7 +102,7 @@ public class OAuthService {
 			return respondWithToken(accessor.requestToken,
 					accessor.tokenSecret, callbackConfirmed);
 		} catch (OAuthException e) {
-			log.warn("Error generating a secret token", e);
+			log.warn("Error generating a request token", e);
 			return respondWithOAuthProblem(e, httpRequest, httpResponse);
 		} catch (IOException e) {
 			throw new IllegalStateException(e);

--- a/oauth-webapp/src/main/java/org/eclipse/lyo/server/oauth/webapp/services/OAuthService.java
+++ b/oauth-webapp/src/main/java/org/eclipse/lyo/server/oauth/webapp/services/OAuthService.java
@@ -90,7 +90,7 @@ public class OAuthService {
 			OAuthRequest oAuthRequest = validateRequest(httpRequest);
 
 			// Generate the token.
-			OAuthConfiguration.getInstance().getTokenStrategy()
+			OAuthConfiguration.getInstance().getJaxTokenStrategy()
 					.generateRequestToken(oAuthRequest);
 			log.trace("Token generated");
 
@@ -132,7 +132,7 @@ public class OAuthService {
 			 */
 			OAuthMessage message = OAuthServlet.getMessage(httpRequest, null);
 			OAuthConfiguration config = OAuthConfiguration.getInstance();
-			String consumerKey = config.getTokenStrategy().validateRequestToken(message);
+			String consumerKey = config.getJaxTokenStrategy().validateRequestToken(message);
 
 			LyoOAuthConsumer consumer = OAuthConfiguration.getInstance().getConsumerStore()
 					.getConsumer(consumerKey);
@@ -195,7 +195,7 @@ public class OAuthService {
 		}
 
 		try {
-			OAuthConfiguration.getInstance().getTokenStrategy()
+			OAuthConfiguration.getInstance().getJaxTokenStrategy()
 					.markRequestTokenAuthorized(httpRequest, requestToken);
 		} catch (OAuthException e) {
 			return Response.status(Status.CONFLICT)
@@ -225,7 +225,7 @@ public class OAuthService {
 
 	private Response authorizeToken(String requestToken, HttpServletRequest httpRequest) {
 		try {
-			OAuthConfiguration.getInstance().getTokenStrategy()
+			OAuthConfiguration.getInstance().getJaxTokenStrategy()
 					.markRequestTokenAuthorized(httpRequest, requestToken);
 		} catch (OAuthException e) {
 			return Response.status(Status.CONFLICT)
@@ -267,7 +267,7 @@ public class OAuthService {
 			// is valid.
 			OAuthRequest oAuthRequest = validateRequest(httpRequest);
 			OAuthConfiguration config = OAuthConfiguration.getInstance();
-			IJaxTokenStrategy strategy = config.getTokenStrategy();
+			IJaxTokenStrategy strategy = config.getJaxTokenStrategy();
 			strategy.validateRequestToken(oAuthRequest.getMessage());
 
 			// The verification code MUST be passed in the request if this is
@@ -492,7 +492,7 @@ public class OAuthService {
 			throws OAuthException {
 		boolean callbackConfirmed = OAuthConfiguration
 				.getInstance()
-				.getTokenStrategy()
+				.getJaxTokenStrategy()
 				.getCallback(oAuthRequest.getAccessor().requestToken) != null;
 		if (callbackConfirmed) {
 			oAuthRequest.getConsumer().setOAuthVersion(
@@ -610,7 +610,7 @@ public class OAuthService {
 				// If this is OAuth 1.0a, the callback was passed when the consumer
 				// asked for a request token.
 				String requestToken = message.getToken();
-				callback = OAuthConfiguration.getInstance().getTokenStrategy()
+				callback = OAuthConfiguration.getInstance().getJaxTokenStrategy()
 						.getCallback(requestToken);
 		}
 
@@ -622,7 +622,7 @@ public class OAuthService {
 				.queryParam(OAuth.OAUTH_TOKEN, message.getToken());
 		if (consumer.getOAuthVersion() == LyoOAuthConsumer.OAuthVersion.OAUTH_1_0A) {
 			String verificationCode = OAuthConfiguration.getInstance()
-					.getTokenStrategy()
+					.getJaxTokenStrategy()
 					.generateVerificationCode(message.getToken());
 			uriBuilder.queryParam(OAuth.OAUTH_VERIFIER, verificationCode);
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,17 @@
   <properties>
     <version.jena>3.13.0</version.jena>
     <version.httpclient>4.5.5</version.httpclient>
-
+    <lyo.version>${project.version}</lyo.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.eclipse.lyo.oslc4j.core</groupId>
+        <artifactId>oslc4j-core</artifactId>
+        <version>${lyo.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>net.oauth.core</groupId>
         <artifactId>oauth</artifactId>
@@ -141,7 +147,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.1.1</version>
           <configuration>
-            <additionalparam>-Xdoclint:none</additionalparam>
+            <doclint>all,-missing</doclint>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
This PR fixes two issues:

- supplying the Lyo base URI in the OAuth request context (see `OAuthRequest(HttpServletRequest request, boolean detectLyoURI)`)
- properly passing POST parameters to the OAuth internals (see `OAuthRequest.OAuthServletRequestWrapper` class and `OAuthService::doPostRequestToken` where its intended use is shown)

This is a pretty major change and I am surprised how it worked before. Apparently, Wink had some extra behaviour that allowed for the input stream to be read multiple times.